### PR TITLE
bump to rightmesh v0.5.0; bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ an event when data is received from another device running the same app as you.
 
 RightMesh abstracts away the idea of IPv4, IPv6 addresses, MAC addresses etc., since any given
 device may have any number of connections into the mesh at a given moment. Instead every device has
-a MeshID which is used in place of these other types of addresses. 
+a `MeshId` which is used in place of these other types of addresses. 
 
-The MeshID is actually an Ethereum compatible account which will be used very soon to keep track
+The `MeshId` is actually an Ethereum compatible account which will be used very soon to keep track
 of how much data has been forwarded and received so that people can be incentivized to use the mesh.
 
 You can send byte arrays of data to other mesh devices and RightMesh will handle reliable
@@ -34,12 +34,13 @@ received on the other side, even when the network grows in size, and despite the
 the devices.
 
 ## Documentation
-Our API reference is available at [https://developer.rightmesh.io/api/](https://developer.rightmesh.io/api/)
+Our API reference is available at https://developer.rightmesh.io/api/
 
-A detailed step-by-step breakdown of how to get started can be found in our reference guide: [https://developer.rightmesh.io/reference/](https://developer.rightmesh.io/reference/)
+A detailed step-by-step breakdown of how to get started can be found in our reference guide:
+https://developer.rightmesh.io/reference/
 
 In order for this sample app to work, you need to obtain RightMesh developer account, and API key
-from our developer website: [https://developer.rightmesh.io/](developer.rightmesh.io)
+from our developer website: https://developer.rightmesh.io/
 
 Set your username, password and key in the app [build.gradle](app/build.gradle) file. The main
 source code is available in [MainActivity.java](app/src/main/java/io/left/hellomesh/MainActivity.java)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
     implementation 'com.android.support:multidex:1.0.3'
-    implementation ('io.left.rightmesh:rightmesh-library:0.4.4')
+    implementation ('io.left.rightmesh:rightmesh-library:0.5.0')
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:appcompat-v7:27.1.1'
 

--- a/app/src/main/java/io/left/hellomesh/MainActivity.kt
+++ b/app/src/main/java/io/left/hellomesh/MainActivity.kt
@@ -12,7 +12,7 @@ import java.util.HashSet
 
 import io.left.rightmesh.android.AndroidMeshManager
 import io.left.rightmesh.android.MeshService
-import io.left.rightmesh.id.MeshID
+import io.left.rightmesh.id.MeshId
 import io.left.rightmesh.mesh.MeshManager
 import io.left.rightmesh.mesh.MeshManager.PeerChangedEvent
 import io.left.rightmesh.mesh.MeshManager.RightMeshEvent
@@ -24,13 +24,13 @@ import io.left.rightmesh.mesh.MeshManager.DATA_RECEIVED
 import io.left.rightmesh.mesh.MeshManager.PEER_CHANGED
 import io.left.rightmesh.mesh.MeshManager.REMOVED
 
-final class MainActivity : Activity(), MeshStateListener {
+class MainActivity : Activity(), MeshStateListener {
 
     // MeshManager instance - interface to the mesh network.
     private lateinit var mm: AndroidMeshManager
 
     // Set to keep track of peers connected to the mesh.
-    private var users: HashSet<MeshID> = HashSet()
+    private var users: HashSet<MeshId> = HashSet()
 
     /**
      * Called when app first opens, initializes [AndroidMeshManager] reference (which will
@@ -38,39 +38,36 @@ final class MainActivity : Activity(), MeshStateListener {
      *
      * @param savedInstanceState passed from operating system
      */
-    protected override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         mm = AndroidMeshManager.getInstance(this@MainActivity, this@MainActivity)
-
     }
 
     /**
      * Called when activity is on screen.
      */
-    protected override fun onResume() {
+    override fun onResume() {
         try {
             super.onResume()
             mm.resume()
         } catch (e: MeshService.ServiceDisconnectedException) {
             e.printStackTrace()
         }
-
     }
 
     /**
      * Called when the app is being closed (not just navigated away from). Shuts down
      * the [AndroidMeshManager] instance.
      */
-    protected override fun onDestroy() {
+    override fun onDestroy() {
         try {
             super.onDestroy()
             mm.stop()
         } catch (e: MeshService.ServiceDisconnectedException) {
             e.printStackTrace()
         }
-
     }
 
     /**
@@ -80,7 +77,7 @@ final class MainActivity : Activity(), MeshStateListener {
      * @param uuid our own user id on first detecting
      * @param state state which indicates SUCCESS or an error code
      */
-    public override fun meshStateChanged(uuid: MeshID, state: Int) {
+    override fun meshStateChanged(uuid: MeshId, state: Int) {
         if (state == MeshStateListener.SUCCESS) {
             try {
                 // Binds this app to MESH_PORT.
@@ -94,16 +91,15 @@ final class MainActivity : Activity(), MeshStateListener {
                 // Enable buttons now that mesh is connected.
                 val btnConfigure = findViewById<Button>(R.id.btnConfigure)
                 val btnSend = findViewById<Button>(R.id.btnHello)
-                btnConfigure.setEnabled(true)
-                btnSend.setEnabled(true)
+                btnConfigure.isEnabled = true
+                btnSend.isEnabled = true
             } catch (e: RightMeshException) {
                 val status = "Error initializing the library" + e.toString()
                 Toast.makeText(this.applicationContext, status, Toast.LENGTH_SHORT).show()
                 val txtStatus = findViewById<TextView>(R.id.txtStatus)
-                txtStatus.setText(status)
+                txtStatus.text = status
                 return
             }
-
         }
 
         // Update display on successful calls (i.e. not FAILURE or DISABLED).
@@ -121,7 +117,7 @@ final class MainActivity : Activity(), MeshStateListener {
             status.append(user.toString()).append("\n")
         }
         val txtStatus = findViewById<TextView>(R.id.txtStatus)
-        txtStatus.setText(status.toString())
+        txtStatus.text = status.toString()
     }
 
     /**
@@ -170,7 +166,7 @@ final class MainActivity : Activity(), MeshStateListener {
     @Throws(RightMeshException::class)
     fun sendHello(v: View) {
         for (receiver in users) {
-            val msg = "Hello to: " + receiver + " from" + mm.getUuid()
+            val msg = "Hello to: " + receiver + " from" + mm.uuid
             MeshUtility.Log(LOG_TAG, "MSG: $msg")
             val testData = msg.toByteArray()
             mm.sendDataReliable(receiver, HELLO_PORT, testData)
@@ -182,13 +178,12 @@ final class MainActivity : Activity(), MeshStateListener {
      *
      * @param v calling view
      */
-    private fun configure(v: View) {
+    fun configure(v: View) {
         try {
             mm.showSettingsActivity()
         } catch (ex: RightMeshException) {
             MeshUtility.Log(LOG_TAG, "Service not connected")
         }
-
     }
 
     companion object {


### PR DESCRIPTION
Version bump:
 - Updated from v0.4.4 to v0.5.0
 - Changed all instances of `MeshID` to `MeshId`, as per breaking
   changes in 0.5.0

Bug fix:
 - Fixed settings activity crash; the `configure()` method was
   previously marked private, so the client could never show the
   MeshManager SettingsActivity

Trivial refactor:
 - Simplified code by replacing setters with directy property access, as
   per Kotlin conventions
 - Removed redundant access modifiers

Tested in small master-client wifi mesh.